### PR TITLE
[ UPDATE-signup ] 회원가입 에러 로직을 업데이트하라

### DIFF
--- a/app/loginPage/loginPage.module.css
+++ b/app/loginPage/loginPage.module.css
@@ -20,19 +20,29 @@
   font-weight: 700;
   text-align: center;
 }
+
 .titleBox {
-  margin: 80px auto;
-  text-align: center;
+  height: 400px;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.titleBox > .textBox { 
+  z-index: 5;
 }
 .titleBox .mainTitle {
   font-family: "Rubik Bubbles";
-  font-size: 70px;
+  font-size: 80px;
 }
 .titleBox .titleImg {
   position: absolute;
-  right: 30px;
-  top: -10px;
+  right: 25px;
+  top: 125px;
+  z-index: 1;
+  /* transform:translateY(-50%); */
 }
 
 .inputBox {

--- a/app/signupPage/components/SignupInputBox.jsx
+++ b/app/signupPage/components/SignupInputBox.jsx
@@ -4,50 +4,56 @@ import Link from "next/link";
 
 import { AuthenticationContext } from "@/app/context/AuthContext";
 import useAuth from "@/hooks/useAuth";
-import styles from "../loginPage.module.css";
+import styles from "../../loginPage/loginPage.module.css";
 import { CircularProgress } from "@mui/material";
 
-export default function LoginInputBox() {
-  const [loginView, setLoginView] = useState(true);
+export default function SignupInputBox() {
   const { error, loading, data, setAuthState } = useContext(
     AuthenticationContext
   );
 
-  const { login } = useAuth();
+  const { signup } = useAuth();
 
   const [loginInputs, setLoginInputs] = useState({
     userid: "",
     password: "",
+    passwordCheck: "",
+    email: "",
   });
 
   const handleChangeInput = (e) => {
     setLoginInputs({ ...loginInputs, [e.target.name]: e.target.value });
   };
 
-  const handleClickLogin = async () => {
-    if (loginInputs.userid == "" || loginInputs.password == "") {
+  const handleClickSignup = async () => {
+    if (
+      loginInputs.email == "" ||
+      loginInputs.userid == "" ||
+      loginInputs.password == "" ||
+      loginInputs.passwordCheck == ""
+    ) {
       alert("빈칸을 채워주세요");
+      return;
     }
-    await login({
+    await signup({
       userid: loginInputs.userid,
       password: loginInputs.password,
+      passwordCheck: loginInputs.passwordCheck,
+      email: loginInputs.email,
     });
-    setLoginInputs({ userid: "", password: "" });
   };
 
   return (
     <div>
       <div className={styles.inputBox}>
-        {!loginView && (
-          <input
-            name="email"
-            type="email"
-            value={loginInputs.email}
-            onChange={handleChangeInput}
-            className={styles.inputItem}
-            placeholder="이메일을 입력하세요"
-          />
-        )}
+        <input
+          name="email"
+          type="email"
+          value={loginInputs.email}
+          onChange={handleChangeInput}
+          className={styles.inputItem}
+          placeholder="이메일을 입력하세요"
+        />
         <input
           name="userid"
           type="text"
@@ -64,16 +70,22 @@ export default function LoginInputBox() {
           className={styles.inputItem}
           placeholder="6-20자 이내의 비밀번호를 입력하세요"
         />
+        <input
+          name="passwordCheck"
+          type="password"
+          value={loginInputs.passwordCheck}
+          onChange={handleChangeInput}
+          className={styles.inputItem}
+          placeholder="비밀번호를 한번 더 입력하세요"
+        />
         <div className={styles.loadingSpinnerBox}>
           {loading && <CircularProgress color="success" />}
         </div>
-        <p className={styles.errorMessage}>
-          {data?.errorMessage && data.errorMessage}
-        </p>
+        <p className={styles.errorMessage}>{error && error.message}</p>
       </div>
       <div className={styles.buttonBox}>
-        <button onClick={handleClickLogin}>로그인</button>
-        <Link href={"/signupPage"}>회원가입 하러 가기</Link>
+        <button onClick={handleClickSignup}>회원가입</button>
+        <Link href={"/loginPage"}> 로그인 하러 가기 </Link>
       </div>
     </div>
   );

--- a/app/signupPage/page.js
+++ b/app/signupPage/page.js
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import styles from "../loginPage/loginPage.module.css";
+import SignupInputBox from "./components/SignupInputBox";
 
 export default function SingupPage() { 
   
@@ -8,31 +9,12 @@ export default function SingupPage() {
     <div className={styles.home}>
       <section className={styles.titleBox}>
         <Image className={styles.titleImg} alt='main-image' src={"/image/toonda.png"} width={70} height={70} />
-        <div>
+        <div className={styles.textBox}>
           <p className={styles.mainTitle}>ToonDa</p>
           <p className={styles.subTitle}>툰다에 오신것을 환영합니다</p>
         </div>
       </section>
-      <form method="POST" action="/api/auth/singup">
-        <div className={styles.inputBox}>
-          <input
-            name="userid"
-            type="text"
-            className={styles.inputItem}
-            placeholder="아이디를 입력하세요"
-          />
-          <input
-            name='password'
-            type="password"
-            className={styles.inputItem}
-            placeholder="비밀번호를 입력하세요"
-          />
-        </div>
-        <div className={styles.buttonBox}>
-          <button type="submit">회원가입</button>
-          <Link href={"./loginPage"}>로그인하러 가기</Link>
-        </div>
-      </form>
+      <SignupInputBox/>
     </div>
   );
 }

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -7,6 +7,7 @@ import { getCookie } from "cookies-next"; // cookies 사용 lib
 export default function useAuth() {
   const { setAuthState } = useContext(AuthenticationContext);
   const router = useRouter();
+
   const login = async ({ userid, password }) => {
     setAuthState({
       data: null,
@@ -21,7 +22,7 @@ export default function useAuth() {
         headers: { "Content-Type": "application/json" },
       })
         .then((r) => {
-          console.log(r);
+          console.log("response--", r);
           if (!r.ok) {
             throw new Error("로그인 실패");
           }
@@ -45,39 +46,39 @@ export default function useAuth() {
     }
   };
 
-  const signup = async ({ userid, password, email }) => {
-    console.log("회원가입", userid, password, email);
+  const signup = async ({ userid, password, email, passwordCheck }) => {
+    console.log("회원가입", userid, password, email, passwordCheck);
     setAuthState({
       data: null,
       error: null,
       loading: true,
     });
+
     try {
-      await fetch("/api/auth/signup", {
+      const res = await fetch("/api/auth/signup", {
         method: "POST",
         body: JSON.stringify({
           userid: userid,
           password: password,
+          passwordCheck: passwordCheck,
           email: email,
         }),
         headers: { "Content-Type": "application/json" },
-      })
-        .then((r) => {
-          if (!r.ok) {
-            throw new Error("회원가입 실패");
-          }
-          return r.json();
-        })
-        .then((result) => {
-          console.log(result);
-          setAuthState({
-            data: result,
-            error: null,
-            loading: false,
-          });
-        });
+      });
+
+      if (!res.ok) {
+        const errorMessage = await res.json();
+        throw new Error(errorMessage.errorMessage);
+      }
+
+      const result = await res.json();
+      setAuthState({
+        data: result,
+        error: null,
+        loading: false,
+      });
+      router.push("/loginPage");
     } catch (error) {
-      console.log("회원가입 Error", error);
       setAuthState({
         data: null,
         error: error,

--- a/pages/api/auth/signup.js
+++ b/pages/api/auth/signup.js
@@ -4,16 +4,19 @@ import bcrypt from "bcrypt"; // 암호화 lib
 
 export default async function handle(req, res) {
   // console.log("--회원가입--", req.body);
-  const { userid, password, email } = req.body;
+  const { userid, password, passwordCheck, email } = req.body;
   const errors = [];
   const db = (await connectDB).db("Toonda");
 
   if (req.method == "POST") {
+    if (password !== passwordCheck) {
+      return res.status(404).json({ errorMessage: "비밀번호를 확인해주세요" });
+    }
     try {
       const validationSchema = [
         {
           valid: validator.isEmail(email),
-          errorMessage: "이메일을 확인해주세요.",
+          errorMessage: "이메일 형식을 확인해주세요.",
         },
         {
           valid: validator.isLength(userid, {
@@ -76,9 +79,7 @@ export default async function handle(req, res) {
       return res.status(200).json("회원가입 성공");
     } catch (error) {
       console.error("Error:", error);
-      return res
-        .status(404)
-        .json("회원가입 실패, 다시 시도해주세요");
+      return res.status(404).json("회원가입 실패, 다시 시도해주세요");
     }
   }
   return res.status(404).json("잘못된 경로입니다");


### PR DESCRIPTION
- 에러 반환하는 try-catch구문을 정리하였다. Error를 제대로 throw하여 catch에서 받을 수 있게 하였다
- 회원 가입 / 로그인 페이지를 각각 사용하기로 하였다 ( 꼬임방지, 코드의 난독화...ㅎ;)
- 이메일과 비밀번호 확인 칸을 추가하여 사용자가 아이디, 이메일, 비밀번호, 비밀번호 확인을 입력해야 한다