### PR TITLE
[ ADD-postEdit ] 수정기능 구현

### DIFF
--- a/app/editPage/[id]/page.js
+++ b/app/editPage/[id]/page.js
@@ -1,63 +1,18 @@
 import { connectDB } from "@/public/utils/database/database";
 import { ObjectId } from "mongodb";
-import styles from "../../postPage/postPage.module.css";
-import Image from "next/image";
-import Link from "next/link";
+import styles from "@/app/postPage/postPage.module.css";
+import EditInputComponent from "../components/EditInputComponent";
 
 export default async function EditPage(props) {
   let db = (await connectDB).db("Toonda");
-  let result = await db
+  let data = await db
     .collection("post")
     .findOne({ _id: new ObjectId(props.params.id) });
 
   return (
     <>
       <div className={styles.home}>
-        <form className={styles.postBox} action="/api/post/edit" method="POST">
-          <input type="hidden" name='id' value={props.params.id}/>
-          <div className={styles.postInputBox}>
-            <input
-              name="date"
-              type="date"
-              defaultValue={result.date}
-              // onChange={(e) => {
-              //   setState({ ...state, date: e.target.value });
-              // }}
-            />
-            <input
-              name="title"
-              // value={state.title}
-              // onChange={(e) => setState({ ...state, title: e.target.value })}
-              type="text"
-              maxLength="20"
-              defaultValue={result.title}
-            />
-          </div>
-          <div className={styles.postTextarea}>
-            <textarea
-              name="content"
-              // value={state.content}
-              // onChange={(e) => setState({ ...state, content: e.target.value })}
-              maxLength="100"
-              defaultValue={result.content}
-            />
-          </div>
-          <div className={styles.postImageBox}>
-            {/* 이미지 변경하지 않았을 때. */}
-            <input type="hidden" name="image" value={result.image} />
-            <div className={styles.labelBox}>
-              <Image
-                src={result.image}
-                alt="image"
-                width={490}
-                height={400}
-              />
-            </div>
-          </div>
-          {/* <ImageComponent/> */}
-          <button type="submit">글 수정 하기</button>
-          <Link href={`/detailPage/${props.params.id}`}>수정 취소</Link>
-        </form>
+        <EditInputComponent postData={data} id={props.params.id}/>
       </div>
     </>
   );

--- a/app/editPage/components/EditImageComponent.jsx
+++ b/app/editPage/components/EditImageComponent.jsx
@@ -1,0 +1,80 @@
+"use client";
+import React, { useContext, useState } from "react";
+import { PostDataContext } from "@/app/context/PostContext";
+import styles from "@/app/postPage/postPage.module.css";
+import Image from "next/image";
+
+export default function EditImageComponent({ imageDefault }) {
+  const { setPostState, imageFile } = useContext(PostDataContext);
+  const [previewImage, setPreviewImage] = useState("");
+
+  const handleImagePreview = async (e) => {
+    const file = e.target.files?.[0];
+    setPostState({
+      postError: null,
+      imageFile: file,
+    });
+
+    // 이미지 미리보기
+    if (file) {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onloadend = () => {
+        setPreviewImage(reader.result);
+      };
+    }
+  };
+
+  return (
+    <div className={styles.postImageBox}>
+      {/* input=file style변경 */}
+      <div className={styles.labelBox}>
+        {/* 실제 image업로드 input */}
+        <input
+          type="file"
+          name="image"
+          id="file"
+          accept="image/*"
+          onChange={handleImagePreview}
+        />
+        {!previewImage ? (
+          <>
+            {/* 기본 default 이미지 */}
+            <label htmlFor="file" className={styles.imageBasicLabel}>
+              <Image
+                src={imageDefault}
+                alt="default-image"
+                width={490}
+                height={400}
+              />
+            </label>
+          </>
+        ) : (
+          <div className={styles.imageEditLabelBox}>
+            <label htmlFor="file" className={styles.imageEditLabel}>
+              <p>이미지 변경</p>
+            </label>
+            <button
+              className={styles.imageEditLabel}
+              onClick={() => {
+                setPreviewImage("");
+              }}
+            >
+              이미지 삭제
+            </button>
+          </div>
+        )}
+      </div>
+      {/* Preview이미지 보여지는 부분 */}
+      {previewImage && (
+        <Image
+          className={styles.previewImg}
+          src={previewImage}
+          width={490}
+          height={400}
+          alt="preview-image"
+        />
+      )}
+    </div>
+  );
+}

--- a/app/editPage/components/EditInputComponent.jsx
+++ b/app/editPage/components/EditInputComponent.jsx
@@ -1,0 +1,111 @@
+"use client";
+import React, { useState, useContext } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+// context, component import
+import { PostDataContext } from "@/app/context/PostContext";
+import { imageUpload } from "@/utils/imageUpload";
+import EditImageComponent from "./EditImageComponent";
+import styles from "@/app/postPage/postPage.module.css";
+
+export default function EditInputComponent({ id, postData }) {
+  const router = useRouter()
+  const { imageFile, setPostState } = useContext(PostDataContext);  
+  const [state, setState] = useState({
+    title: null,
+    content: null,
+    date: null,
+  });
+
+  const handleClickEditPost = async (e) => {
+    e.preventDefault();
+    try {
+      // S3이미지 업로드
+      const imageS3Upload = await imageUpload(imageFile);
+
+      // 수정 DATA
+      const editData = {
+        _id: id,
+        date: state.date == null ? postData?.date : state.date,
+        title: state.title == null ? postData?.title : state.title,
+        content: state.content == null ? postData?.content : state.content,
+        image: imageS3Upload == null ? postData?.image : imageS3Upload,
+        user: postData?.user,
+        createDate: new Date().getTime(),
+      };
+
+      if (editData.date == "" || editData.title == "" || editData.content == "") {
+        alert("빈칸을 채워주세요");
+        return;
+      }
+
+      await fetch(`/api/post/edit`, {
+        method: "POST",
+        body: JSON.stringify(editData),
+        headers: { "Content-Type": "application/json" },
+      })
+        .then((res) => {
+          if (res.ok) {
+            return res.json();
+          } else {
+            throw new Error("포스트 작성에 문제가 발생하였습니다.") 
+          }
+        })
+        .then((result) => {
+          try {
+            setState({ title: null, content: null, date: null });
+            setPostState({ postError: null, imageFile: null });
+            alert(result);
+            router.push(`/detailPage/${id}`);
+            router.refresh();
+          } catch (error) {
+            // 서버 PostData저장 Error Catch
+            alert(error);
+          }
+        });
+    } catch (error) {
+      // 이미지 업로드 Error Catch
+      alert(error);
+    }
+  };
+
+  return (
+    <div className={styles.postBox}>
+      <input type="hidden" name="id" value={id} />
+      <div className={styles.postInputBox}>
+        <input
+          name="date"
+          type="date"
+          defaultValue={postData.date}
+          onChange={(e) => {
+            setState({ ...state, date: e.target.value });
+          }}
+        />
+        <input
+          name="title"
+          type="text"
+          onChange={(e) => setState({ ...state, title: e.target.value })}
+          defaultValue={postData.title}
+          maxLength="20"
+        />
+      </div>
+      <div className={styles.postTextarea}>
+        <textarea
+          name="content"
+          defaultValue={postData.content}
+          onChange={(e) => setState({ ...state, content: e.target.value })}
+          maxLength="100"
+        />
+      </div>
+      <EditImageComponent imageDefault={postData.image} />
+      <div className={styles.postButtonBox}>
+        <button className={styles.postButton} onClick={handleClickEditPost}>
+          글 수정 하기
+        </button>
+        <Link className={styles.postButton} href={`/detailPage/${id}`}>
+          수정 취소
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/utils/imageUpload.js
+++ b/utils/imageUpload.js
@@ -1,0 +1,34 @@
+export const imageUpload = async(imageFile)=>{
+  let uploadSrc = null
+  if (imageFile) {
+    const filename = encodeURIComponent(imageFile.name);
+
+    // presigned URL발행
+    const res = await fetch(`/api/post/image?file=${filename}`);
+    if(!res.ok)throw new Error(" 이미지 업로드에 문제가 생겼습니다. 다시 시도해주세요")
+    const presignedUrlData = await res.json();        
+
+    // S3-upload
+    // res.fields=서버가 보낸 정보 / file= 유저 이미지정보 => upload
+    const formData = new FormData();
+    Object.entries({ ...presignedUrlData.fields, file: imageFile }).forEach(
+      ([key, value]) => {
+        formData.append(key, value);
+      }
+    );
+
+    let upload = await fetch(presignedUrlData.url, {
+      method: "POST",
+      body: formData,
+    });
+
+    if (upload.ok) {
+      uploadSrc = `${upload.url}/${filename}`;
+      // console.log("S3-upload URL --", uploadSrc);
+    } else {
+      throw new Error(" 이미지 업로드에 문제가 생겼습니다. 다시 시도해주세요")
+    }
+  }
+  
+  return uploadSrc
+}


### PR DESCRIPTION
- 서버컴포넌트로 mongodb에서 데이터를 받아 수정할 클라이언트 컴포넌트에 넘겨준다
- editInput컴포넌트에서는 사용자의 수정데이터를 받아서 서버로 edit요청을 한다
- 이때 이미지 컴포넌트는 따로 생성하여 이미지 미리보기 기능을 추가로 구현
- 또한 이미지 S3업로드도 util함수로 작성하여 컴포넌트에서 함수를 호출 및 imageFile을 인자로 넘겨 S3업로드를 수행한다
- util함수에서는 업로드 된 url을 반환하여 editInput컴포넌트에서 사용할 수 있도록 하였다
- post / edit의 기능이 비슷하므로 이후 두 컴포넌트를 합쳐서 구현해볼 생각