### PR TITLE
[ ADD-inputComponent / UPDATE-contextAPI ] postpage에서 input컴포넌트를 생성해 분리하라, 동시에 postContext로 생성하라.

### DIFF
--- a/app/context/ImageContext.jsx
+++ b/app/context/ImageContext.jsx
@@ -1,0 +1,26 @@
+"use client";
+import React, { useState, createContext } from "react";
+
+// Context를 생성하고 어디서든 사용할 수 있도록 export한다
+export const ImageDataContext = createContext({
+  imageFile: null,
+  setImageState: () => {},
+});
+export default function ImageContext({ children }) {
+  // state를 생성한다
+  const [imageState, setImageState] = useState({
+    imageFile: null,
+  });
+
+  // Context를 전역으로 공급한다. 이후 layout에 전역으로 공급할 수 있도록 태그를 감싼다.
+  return (
+    <ImageDataContext.Provider
+      value={{
+        ...imageState,
+        setImageState,
+      }}
+    >
+      {children}
+    </ImageDataContext.Provider>
+  );
+}

--- a/app/context/PostContext.jsx
+++ b/app/context/PostContext.jsx
@@ -1,25 +1,29 @@
 "use client";
-import React, { useState, createContext, useEffect } from "react";
+import React, { useState, createContext } from "react";
 
 // Context를 생성하고 어디서든 사용할 수 있도록 export한다
 export const PostDataContext = createContext({
-  postError: null,
-  imageFile: null,
+  postState: {
+    title: "",
+    content: "",
+    date: "",
+  },
   setPostState: () => {},
 });
 
 export default function PostContext({ children }) {
   // state를 생성한다
   const [postState, setPostState] = useState({
-    postError: null,
-    imageFile: null,
+    title: "",
+    content: "",
+    date: "",
   });
 
   // Context를 전역으로 공급한다. 이후 layout에 전역으로 공급할 수 있도록 태그를 감싼다.
   return (
     <PostDataContext.Provider
       value={{
-        ...postState,
+        postState,
         setPostState,
       }}
     >

--- a/app/editPage/components/EditImageComponent.jsx
+++ b/app/editPage/components/EditImageComponent.jsx
@@ -1,20 +1,17 @@
 "use client";
 import React, { useContext, useState } from "react";
-import { PostDataContext } from "@/app/context/PostContext";
-import styles from "@/app/postPage/postPage.module.css";
 import Image from "next/image";
+import { ImageDataContext, } from "@/app/context/ImageContext";
 import { imagePreviewUtil } from "@/utils/imageUpload";
+import styles from "@/app/postPage/postPage.module.css";
 
 export default function EditImageComponent({ imageDefault }) {
-  const { setPostState, imageFile } = useContext(PostDataContext);
+  const { setImageState, imageFile } = useContext(ImageDataContext);
   const [previewImage, setPreviewImage] = useState("");
 
   const handleImagePreview = async (e) => {
     const file = e.target.files?.[0];
-    setPostState({
-      postError: null,
-      imageFile: file,
-    });
+    setImageState({ imageFile: file });
 
     // image 미리보기
     if(file){
@@ -22,7 +19,7 @@ export default function EditImageComponent({ imageDefault }) {
       setPreviewImage(preview);
     }
   };
-  
+
   return (
     <div className={styles.postImageBox}>
       {/* input=file style변경 */}

--- a/app/editPage/components/EditInputComponent.jsx
+++ b/app/editPage/components/EditInputComponent.jsx
@@ -3,7 +3,7 @@ import { useContext } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 // context, util, hooks import
-import { PostDataContext } from "@/app/context/PostContext";
+import { ImageDataContext } from "@/app/context/ImageContext";
 import { imageUploadUtil } from "@/utils/imageUpload";
 import useInput from "@/hooks/useInput";
 import usePostApi from "@/hooks/usePostApi";
@@ -11,10 +11,9 @@ import usePostApi from "@/hooks/usePostApi";
 import EditImageComponent from "./EditImageComponent";
 import styles from "@/app/postPage/postPage.module.css";
 
-
 export default function EditInputComponent({ id, postData }) {
   const router = useRouter();
-  const { imageFile, setPostState } = useContext(PostDataContext);
+  const { imageFile, setImageState } = useContext(ImageDataContext);
   const { postDataFetchingApi } = usePostApi();
 
   const initialData = {
@@ -50,7 +49,7 @@ export default function EditInputComponent({ id, postData }) {
       const editResult = await postDataFetchingApi("edit", data);
       if (!editResult) throw new Error("포스트 작성에 문제가 발생하였습니다.");
       resetState();
-      setPostState({ postError: null, imageFile: null });
+      setImageState({ imageFile: null });
       alert(editResult);
       router.push(`/detailPage/${id}`);
       router.refresh();

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,7 @@
 import NavBar from "./components/NavBar";
 import AuthContext from "./context/AuthContext";
 import PostContext from "./context/PostContext";
+import ImageContext from "./context/ImageContext";
 import "./globals.css";
 import localFont from "next/font/local";
 
@@ -16,23 +17,6 @@ export const noonnu = localFont({
   display: "swap",
 });
 
-// const noonnu = localFont({
-//   src: [
-//     {
-//       path: "./font/RussoOne-Regular.ttf", // 로고font
-//       display: "swap",
-//     },
-//     {
-//       path: "./font/RubikBubbles-Regular.ttf",
-//       display: "swap",
-//     },
-//     {
-//       path: "./font/강원교육모두 Light.ttf",
-//       display: "swap",
-//     },
-//   ],
-// });
-
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
@@ -42,8 +26,10 @@ export default function RootLayout({ children }) {
       <body className={noonnu.className}>
         <AuthContext >
           <PostContext>
-            <NavBar/>
-            {children}
+            <ImageContext>
+              <NavBar/>
+              {children}
+            </ImageContext>
           </PostContext>
         </AuthContext>
       </body>

--- a/app/postPage/components/ImageComponent.jsx
+++ b/app/postPage/components/ImageComponent.jsx
@@ -1,20 +1,17 @@
 "use client";
 import React, { useContext, useState } from "react";
-import { PostDataContext } from "@/app/context/PostContext";
+import { ImageDataContext } from "@/app/context/ImageContext";
 import styles from "../postPage.module.css";
 import Image from "next/image";
 import { imagePreviewUtil } from "@/utils/imageUpload";
 
 export default function ImageComponent() {
-  const { setPostState } = useContext(PostDataContext);
+  const { setImageState } = useContext(ImageDataContext);
   const [previewImage, setPreviewImage] = useState("");
 
   const handleImagePreview = async (e) => {
     const file = e.target.files?.[0];
-    setPostState({
-      postError: null,
-      imageFile: file,
-    });
+    setImageState({ imageFile: file });
 
     // image 미리보기
     if (file) {
@@ -56,10 +53,7 @@ export default function ImageComponent() {
             </label>
             <button
               className={styles.imageEditLabel}
-              onClick={() => {
-                setPreviewImage("");
-                setEncodeFilename("");
-              }}
+              onClick={() => setPreviewImage("")}
             >
               이미지 삭제
             </button>

--- a/app/postPage/components/InputComponent.jsx
+++ b/app/postPage/components/InputComponent.jsx
@@ -1,0 +1,40 @@
+"use client";
+import { useContext } from "react";
+import { PostDataContext } from "@/app/context/PostContext";
+import useInput from "@/hooks/useInput";
+import styles from "../postPage.module.css";
+
+export default function InputComponent() {
+  const { setPostState, postState } = useContext(PostDataContext);
+  const [ state, setState ] = useInput()
+
+  return (
+    <>
+      <div className={styles.postInputBox}>
+        <input 
+          name='date'
+          type="date" 
+          value={postState?.date} 
+          onChange={(e) => setState("date", e.target.value)}
+        />
+        <input
+          type="text"
+          name="title"
+          value={postState?.title}
+          onChange={(e) => setState("title", e.target.value)}
+          maxLength="20"
+          placeholder="툰 제목을 입력해주세요"
+        />
+      </div>
+      <div className={styles.postTextarea}>
+        <textarea
+          name="content"
+          value={postState?.content}
+          onChange={(e) => setState("content", e.target.value)}
+          maxLength="100"
+          placeholder="오늘의 툰을 설명해주세요"
+        />
+      </div>
+    </>
+  );
+}

--- a/app/postPage/page.js
+++ b/app/postPage/page.js
@@ -11,13 +11,15 @@ import usePostApi from "@/hooks/usePostApi";
 import styles from "./postPage.module.css";
 import ImageComponent from "./components/ImageComponent";
 import InputComponent from "./components/InputComponent";
+import useInput from "@/hooks/useInput";
 
 export default function PostPage() {
   const router = useRouter();
   const { data } = useContext(AuthenticationContext);
+  const { postState } = useContext(PostDataContext);
   const { setImageState, imageFile } = useContext(ImageDataContext);
-  const { setPostState, postState } = useContext(PostDataContext);
   const { postDataFetchingApi } = usePostApi();
+  const [ resetState ] = useInput()
 
   const handleClickPostAdd = async (e) => {
     e.preventDefault();
@@ -45,7 +47,7 @@ export default function PostPage() {
       const postResult = await postDataFetchingApi("new", newData);
       if (!postResult) throw new Error("포스트 작성에 문제가 발생하였습니다.");
       setImageState({imageFile: null});
-      setPostState({ title: "", content: "", date: ""})
+      resetState()
       alert(postResult);
       router.push("/");
       router.refresh();

--- a/app/postPage/page.js
+++ b/app/postPage/page.js
@@ -4,29 +4,28 @@ import { useRouter } from "next/navigation";
 // context, util, hooks import
 import { AuthenticationContext } from "@/app/context/AuthContext";
 import { PostDataContext } from "@/app/context/PostContext";
+import { ImageDataContext } from "@/app/context/ImageContext";
 import { imageUploadUtil } from "@/utils/imageUpload";
-import useInput from "@/hooks/useInput";
 import usePostApi from "@/hooks/usePostApi";
 // component, style import
 import styles from "./postPage.module.css";
 import ImageComponent from "./components/ImageComponent";
+import InputComponent from "./components/InputComponent";
 
 export default function PostPage() {
   const router = useRouter();
   const { data } = useContext(AuthenticationContext);
-  const { setPostState, imageFile } = useContext(PostDataContext);
+  const { setImageState, imageFile } = useContext(ImageDataContext);
+  const { setPostState, postState } = useContext(PostDataContext);
   const { postDataFetchingApi } = usePostApi();
-
-  const initialData = {
-    title: '',
-    content: '',
-    date: '',
-  };
-  const [state, setState, resetState] = useInput(initialData);
 
   const handleClickPostAdd = async (e) => {
     e.preventDefault();
-    if (state.date == "" || state.title == "" || state.content == "") {
+    if (
+      postState.date == "" ||
+      postState.title == "" ||
+      postState.content == ""
+    ) {
       alert("빈칸을 채워주세요");
       return;
     }
@@ -34,24 +33,22 @@ export default function PostPage() {
     try {
       // S3이미지 업로드
       const imageS3Upload = await imageUploadUtil(imageFile);
-
       const newData = {
-        date: state.date,
-        title: state.title,
-        content: state.content,
+        date: postState.date,
+        title: postState.title,
+        content: postState.content,
         image: imageS3Upload == null ? "/image/free.jpg" : imageS3Upload,
         user: data?.userid,
         createDate: new Date().getTime(),
       };
-      
       // post작성 API
       const postResult = await postDataFetchingApi("new", newData);
       if (!postResult) throw new Error("포스트 작성에 문제가 발생하였습니다.");
-      resetState();
-      setPostState({ postError: null, imageFile: null });
+      setImageState({imageFile: null});
+      setPostState({ title: "", content: "", date: ""})
       alert(postResult);
       router.push("/");
-
+      router.refresh();
     } catch (error) {
       // 이미지 업로드 Error Catch
       alert(error);
@@ -61,28 +58,7 @@ export default function PostPage() {
   return (
     <div className={styles.home}>
       <div className={styles.postBox}>
-        <div className={styles.postInputBox}>
-          <input
-            type="date"
-            value={state?.date}
-            onChange={(e) => setState("date", e.target.value)}
-          />
-          <input
-            type="text"
-            value={state?.title}
-            onChange={(e) => setState("title", e.target.value)}
-            maxLength="20"
-            placeholder="툰 제목을 입력해주세요"
-          />
-        </div>
-        <div className={styles.postTextarea}>
-          <textarea
-            value={state?.content}
-            onChange={(e) => setState("content", e.target.value)}
-            maxLength="100"
-            placeholder="오늘의 툰을 설명해주세요"
-          />
-        </div>
+        <InputComponent />
         <ImageComponent />
         <div className={styles.postButtonBox}>
           <button className={styles.postButton} onClick={handleClickPostAdd}>

--- a/app/postPage/postPage.module.css
+++ b/app/postPage/postPage.module.css
@@ -82,6 +82,9 @@
 .postBox .postImageBox .labelBox label {
   cursor: pointer;
 }
+.postBox .postImageBox .labelBox .imageBasicLabel img{
+  object-fit: cover
+}
 .postBox .postImageBox .labelBox .imageEditLabelBox {
   display: flex;
 }

--- a/hooks/useInput.js
+++ b/hooks/useInput.js
@@ -1,15 +1,21 @@
-import { useState } from "react";
+import { useContext } from "react";
+import { PostDataContext } from "@/app/context/PostContext";
 
 // Custom Hook 정의
-export default function useInput(initialState) {
-  const [state, setState] = useState(initialState);
+export default function useInput() {
+  const { setPostState, postState } = useContext(PostDataContext);
 
   const handleChange = (key, value) => {
-    setState({ ...state, [key]: value });
+    setPostState({ ...postState, [key]: value });
   };
 
   const resetState = () => {
-    setState(initialState);
+    setPostState({
+      date: "",
+      title: "",
+      content: "",
+    });
   };
-  return [state, handleChange, resetState];
+
+  return [ resetState, handleChange ]
 }


### PR DESCRIPTION
- input컴포넌트를 생성하면서 input과 관련한 contextAPI의 필요성을 느끼게 되었다. image데이터만 처리하면 되는 곳에서 굳이 post데이터까지 처리할 필요는 없으므로 image와 post의 Context를 분리하게 되었다.
- input컴포넌트에서 input의 onChange부분과 초기화 하는 부분은 hooks으로 처리하였다. 